### PR TITLE
Simplifying Left and Right-Click Handling

### DIFF
--- a/Tower_of_Lights_Editor_V3/Tower_of_Lights_Editor_V3.pro.user
+++ b/Tower_of_Lights_Editor_V3/Tower_of_Lights_Editor_V3.pro.user
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.1.0, 2016-11-30T10:39:30. -->
+<!-- Written by QtCreator 4.1.0, 2016-11-30T16:25:34. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
-  <value type="QByteArray">{58f5ac71-7146-437e-bde3-e3487c7b0770}</value>
+  <value type="QByteArray">{4371d23d-b6d6-49e4-a8e1-7e1640540341}</value>
  </data>
  <data>
   <variable>ProjectExplorer.Project.ActiveTarget</variable>
@@ -59,14 +59,14 @@
  <data>
   <variable>ProjectExplorer.Project.Target.0</variable>
   <valuemap type="QVariantMap">
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Desktop Qt 5.7.0 clang 64bit</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Desktop Qt 5.7.0 clang 64bit</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">qt.57.clang_64_kit</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Desktop Qt 5.7.0 MSVC2015_64bit</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Desktop Qt 5.7.0 MSVC2015_64bit</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">qt.57.win64_msvc2015_64_kit</value>
    <value type="int" key="ProjectExplorer.Target.ActiveBuildConfiguration">0</value>
    <value type="int" key="ProjectExplorer.Target.ActiveDeployConfiguration">0</value>
    <value type="int" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.0">
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/Users/iantanimoto/Documents/cs383project/build-Tower_of_Lights_Editor_V3-Desktop_Qt_5_7_0_clang_64bit-Debug</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">C:/Users/gabe_000/Documents/Attending University/CS/CS383/Project/Repository/cs383project/build-Tower_of_Lights_Editor_V3-Desktop_Qt_5_7_0_MSVC2015_64bit-Debug</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
@@ -84,10 +84,7 @@
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
-      <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.AutomaticallyAddedMakeArguments">
-       <value type="QString">-w</value>
-       <value type="QString">-r</value>
-      </valuelist>
+      <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.AutomaticallyAddedMakeArguments"/>
       <value type="bool" key="Qt4ProjectManager.MakeStep.Clean">false</value>
       <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments"></value>
       <value type="QString" key="Qt4ProjectManager.MakeStep.MakeCommand"></value>
@@ -103,10 +100,7 @@
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
-      <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.AutomaticallyAddedMakeArguments">
-       <value type="QString">-w</value>
-       <value type="QString">-r</value>
-      </valuelist>
+      <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.AutomaticallyAddedMakeArguments"/>
       <value type="bool" key="Qt4ProjectManager.MakeStep.Clean">true</value>
       <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
       <value type="QString" key="Qt4ProjectManager.MakeStep.MakeCommand"></value>
@@ -126,7 +120,7 @@
     <value type="bool" key="Qt4ProjectManager.Qt4BuildConfiguration.UseShadowBuild">true</value>
    </valuemap>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.1">
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/Users/iantanimoto/Documents/cs383project/build-Tower_of_Lights_Editor_V3-Desktop_Qt_5_7_0_clang_64bit-Release</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">C:/Users/gabe_000/Documents/Attending University/CS/CS383/Project/Repository/cs383project/build-Tower_of_Lights_Editor_V3-Desktop_Qt_5_7_0_MSVC2015_64bit-Release</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
@@ -144,10 +138,7 @@
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
-      <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.AutomaticallyAddedMakeArguments">
-       <value type="QString">-w</value>
-       <value type="QString">-r</value>
-      </valuelist>
+      <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.AutomaticallyAddedMakeArguments"/>
       <value type="bool" key="Qt4ProjectManager.MakeStep.Clean">false</value>
       <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments"></value>
       <value type="QString" key="Qt4ProjectManager.MakeStep.MakeCommand"></value>
@@ -163,10 +154,7 @@
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
-      <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.AutomaticallyAddedMakeArguments">
-       <value type="QString">-w</value>
-       <value type="QString">-r</value>
-      </valuelist>
+      <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.AutomaticallyAddedMakeArguments"/>
       <value type="bool" key="Qt4ProjectManager.MakeStep.Clean">true</value>
       <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
       <value type="QString" key="Qt4ProjectManager.MakeStep.MakeCommand"></value>
@@ -186,7 +174,7 @@
     <value type="bool" key="Qt4ProjectManager.Qt4BuildConfiguration.UseShadowBuild">true</value>
    </valuemap>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.2">
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/Users/iantanimoto/Documents/cs383project/build-Tower_of_Lights_Editor_V3-Desktop_Qt_5_7_0_clang_64bit-Profile</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">C:/Users/gabe_000/Documents/Attending University/CS/CS383/Project/Repository/cs383project/build-Tower_of_Lights_Editor_V3-Desktop_Qt_5_7_0_MSVC2015_64bit-Profile</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
@@ -204,10 +192,7 @@
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
-      <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.AutomaticallyAddedMakeArguments">
-       <value type="QString">-w</value>
-       <value type="QString">-r</value>
-      </valuelist>
+      <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.AutomaticallyAddedMakeArguments"/>
       <value type="bool" key="Qt4ProjectManager.MakeStep.Clean">false</value>
       <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments"></value>
       <value type="QString" key="Qt4ProjectManager.MakeStep.MakeCommand"></value>
@@ -223,10 +208,7 @@
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
-      <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.AutomaticallyAddedMakeArguments">
-       <value type="QString">-w</value>
-       <value type="QString">-r</value>
-      </valuelist>
+      <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.AutomaticallyAddedMakeArguments"/>
       <value type="bool" key="Qt4ProjectManager.MakeStep.Clean">true</value>
       <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
       <value type="QString" key="Qt4ProjectManager.MakeStep.MakeCommand"></value>
@@ -304,13 +286,13 @@
     <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Tower_of_Lights_Editor_V3</value>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/Users/iantanimoto/Documents/cs383project/Tower_of_Lights_Editor_V3/Tower_of_Lights_Editor_V3.pro</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:C:/Users/gabe_000/Documents/Attending University/CS/CS383/Project/Repository/cs383project/Tower_of_Lights_Editor_V3/Tower_of_Lights_Editor_V3.pro</value>
     <value type="bool" key="QmakeProjectManager.QmakeRunConfiguration.UseLibrarySearchPath">true</value>
     <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.CommandLineArguments"></value>
     <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.ProFile">Tower_of_Lights_Editor_V3.pro</value>
     <value type="bool" key="Qt4ProjectManager.Qt4RunConfiguration.UseDyldImageSuffix">false</value>
     <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory"></value>
-    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory.default">/Users/iantanimoto/Documents/cs383project/build-Tower_of_Lights_Editor_V3-Desktop_Qt_5_7_0_clang_64bit-Debug/Tower_of_Lights_Editor_V3.app/Contents/MacOS</value>
+    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory.default">C:/Users/gabe_000/Documents/Attending University/CS/CS383/Project/Repository/cs383project/build-Tower_of_Lights_Editor_V3-Desktop_Qt_5_7_0_MSVC2015_64bit-Debug</value>
     <value type="uint" key="RunConfiguration.QmlDebugServerPort">3768</value>
     <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>

--- a/Tower_of_Lights_Editor_V3/cell.cpp
+++ b/Tower_of_Lights_Editor_V3/cell.cpp
@@ -1,7 +1,5 @@
 // Class for a custom cell display widget
 #include "cell.h"
-#include "TanFile.h"
-#include "mainwindow.h"   //access to project data
 
 // Constructor
 CellWidget::CellWidget(QString name, int x, int y, QColor color, QWidget *parent)
@@ -22,6 +20,7 @@ CellWidget::CellWidget(QString name, int x, int y, QColor color, QWidget *parent
 	}
 }
 
+
 // Destructor
 CellWidget::~CellWidget()
 {
@@ -35,11 +34,13 @@ int CellWidget::getRow()
 	return _row;
 }
 
+
 // Return this widget's column, corresponding with an index in TanFrame
 int CellWidget::getColumn()
 {
 	return _col;
 }
+
 
 // Sets the background color of this widget
 // Returns the color that was set, for verification purposes
@@ -59,15 +60,17 @@ QColor CellWidget::setColor(QColor rgb)
 	return getColor();
 }
 
+
 // Calls setColor(), and then triggers the colorChanged() signal
 // Returns the color that was set, for verification purposes
-/*QColor CellWidget::changeColor(QColor rgb)
+QColor CellWidget::changeColor(QColor rgb)
 {
 	setColor(rgb);
 
 	emit colorChanged(getRow(), getColumn(), getColor());
 	return getColor();
-}*/
+}
+
 
 // Return the current color
 QColor CellWidget::getColor()
@@ -75,11 +78,13 @@ QColor CellWidget::getColor()
 	return _color;
 }
 
+
 // Returns the current state of the widget, indicating currently selected or not
 bool CellWidget::getState()
 {
 	return _state;
 }
+
 
 // Custom event handler
 bool CellWidget::event(QEvent *event)
@@ -88,22 +93,30 @@ bool CellWidget::event(QEvent *event)
 	if (event->type() == QEvent::MouseButtonPress)
 	{
 		QMouseEvent *qme = static_cast<QMouseEvent*>(event);
-		// Handle left-click here
-		if (qme->button() == Qt::LeftButton)
-            emit leftClick(getRow(),getColumn(),getColor()); //left click signal
+		char btn = 'X';
 
+		// Handle left-click here
+		// Left-click changes the color based on
+		// the current leftColor of the Tan file representation
+		if (qme->button() == Qt::LeftButton) {
+			btn = 'L';
+		}
+		// Handle right-click here
+		// Right-click changes the color based on
+		// the current rightColor of the Tan file representation
 		else if (qme->button() == Qt::RightButton)
 		{
-            emit rightClick(getRow(),getColumn(),getColor()); //right click signal
-            //changeColor(baseColor);
+			btn = 'R';
+		}
 
-			_state = false;
-			return true;
-        }
+		emit clicked(getRow(), getColumn(), btn);
+		return true;
 	}
-
-	// Pass all other events down to the base class
-	return QWidget::event(event);
+	else
+	{
+		// Pass all other events down to the base class
+		return QWidget::event(event);
+	}
 }
 
 

--- a/Tower_of_Lights_Editor_V3/cell.h
+++ b/Tower_of_Lights_Editor_V3/cell.h
@@ -12,14 +12,14 @@
 
 class CellWidget : public QWidget {
 
-    Q_OBJECT
+	Q_OBJECT
 
 public:
-    CellWidget(QString name, int x, int y, QColor color = QColor(Qt::black), QWidget *parent=Q_NULLPTR);
+	CellWidget(QString name, int x, int y, QColor color = QColor(Qt::black), QWidget *parent=Q_NULLPTR);
 	~CellWidget();
 
-    int getRow();
-    int getColumn();
+	int getRow();
+	int getColumn();
 
 	QColor setColor(QColor rgb);
 	QColor changeColor(QColor rgb);
@@ -29,21 +29,19 @@ public:
 
 signals:
 
-    //void colorChanged(const int row, const int col, QColor color);
-    void rightClick(const int row,const int col,QColor color); //right click
-    void leftClick(const int row,const int col,QColor color);  //left click
+	void colorChanged(const int row,const int col,QColor color);
 
-	void clicked(const int row, const int col);
+	void clicked(const int row,const int col,const char btn);
 
-	void selected(const int row, const int col);
+	void selected(const int row,const int col);
 
 private slots:
 
 protected:
 
-    bool event(QEvent *event);
+	bool event(QEvent *event);
 
-    void paintEvent(QPaintEvent *event);
+	void paintEvent(QPaintEvent *event);
 
 private:
 

--- a/Tower_of_Lights_Editor_V3/mainwindow.cpp
+++ b/Tower_of_Lights_Editor_V3/mainwindow.cpp
@@ -17,7 +17,10 @@ MainWindow::MainWindow(QWidget *parent) :
     createMenus();
 
     m_generateFrame(TAN_DEFAULT_ROWS, TAN_DEFAULT_COLS);
-    nothingToSave = true;
+		project.setLeftColor(255,255,255);
+		project.setRightColor(255,255,255);
+		updateGUIColorButtons();
+		nothingToSave = true;
 }
 
 MainWindow::~MainWindow()
@@ -207,20 +210,17 @@ void MainWindow::saveAs()
 // Create the grid of cell widgets
 void MainWindow::m_generateFrame(int rows, int cols)
 {
-    project.setLeftColor(255,255,255);
-    project.setRightColor(255,255,255);
-    updateGUIColorButtons();
 	int i = 0, j = 0;
 	//QFrame *m_Frame = ui->frame;
-    QGridLayout *m_FrameLayout = ui->gridLayout;
+	QGridLayout *m_FrameLayout = ui->gridLayout;
 	QString m_cellName;
 	QSizePolicy m_cellSizePolicy;
-    QSize m_cellSize(18,18);	// Arbitrarily selected as a decent minimum ("quarter-inch" @ 72 ppi, less @ 96 ppi or higher resolutions)
+	QSize m_cellSize(18,18);	// Arbitrarily selected as a decent minimum ("quarter-inch" @ 72 ppi, less @ 96 ppi or higher resolutions)
 
 	// Configure the size policy that every cell widget will use
-    m_cellSizePolicy.setHorizontalPolicy(QSizePolicy::Fixed);
+	m_cellSizePolicy.setHorizontalPolicy(QSizePolicy::Fixed);
 	m_cellSizePolicy.setHorizontalStretch(1);
-    m_cellSizePolicy.setVerticalPolicy(QSizePolicy::Fixed);
+	m_cellSizePolicy.setVerticalPolicy(QSizePolicy::Fixed);
 	m_cellSizePolicy.setVerticalStretch(1);
 	m_cellSizePolicy.setHeightForWidth(true);
 
@@ -230,8 +230,8 @@ void MainWindow::m_generateFrame(int rows, int cols)
 		{
 			// Generate the name for each cell, based on rows and cols
 			// Relocate this job to TanFrame project at some point?
-            m_cellName = "cell" + (QString("%1").arg((i*cols + j), 3, 10, QChar('0')));
-            CellWidget *m_cellWidget = new CellWidget(m_cellName, i, j);
+			m_cellName = "cell" + (QString("%1").arg((i*cols + j), 3, 10, QChar('0')));
+			CellWidget *m_cellWidget = new CellWidget(m_cellName, i, j);
 			m_cellWidget->setMinimumSize(m_cellSize);
 			m_cellWidget->setSizePolicy(m_cellSizePolicy);
 
@@ -269,48 +269,43 @@ void MainWindow::m_destroyFrame(int rows, int cols)
 // Connecting all the cells to the same click handler
 void MainWindow::m_connectCellSignals(CellWidget *m_cell)
 {
-    //connect(m_cell, SIGNAL(colorChanged(const int, const int, QColor)), this, SLOT(on_cell_colorChanged(const int, const int, QColor)));
-    connect(m_cell, SIGNAL(rightClick(const int, const int, QColor)), this, SLOT(on_cell_rightChanged(const int, const int, QColor)));
-    connect(m_cell, SIGNAL(leftClick(const int, const int, QColor)), this, SLOT(on_cell_leftChanged(const int, const int, QColor)));
+	connect(m_cell, SIGNAL(clicked(const int, const int, const char)), this, SLOT(on_cell_clicked(const int, const int, const char)));
 }
 
 
-// The primary handler for cell clicks
-/*void MainWindow::on_cell_colorChanged(const int row, const int col, QColor m_color)
+// Slot to respond to cell clicks
+// Determines the color to use, based on which type of click (left or right)
+// Updates the displayed color in the clicked cell and
+// updates appropriate frame of Tan file representation with color information
+void MainWindow::on_cell_clicked(const int row, const int col, const char btn)
 {
-    //take provided color and assign it to the
-    QString m_cellName = m_getObjName(QObject::sender());
-    CellWidget *m_cell = MainWindow::findChild<CellWidget*>(m_cellName);
+	QString m_cellName = m_getObjName(QObject::sender());
+	CellWidget *m_cell = MainWindow::findChild<CellWidget*>(m_cellName);
+	QColor m_color = Qt::black;
 
-    m_setCellColor(m_cell);
-    m_updateTanFileColor(row, col, m_color);   //updates project's appropriate frame with color information
-
-}*/
-void MainWindow::on_cell_leftChanged(const int row, const int col, QColor m_color)
-{
-    nothingToSave = false;
-    //take provided color and assign it to the
-    QString m_cellName = m_getObjName(QObject::sender());
-    CellWidget *m_cell = MainWindow::findChild<CellWidget*>(m_cellName);
-    m_setCellColor(m_cell,project.getLeftColor());
-    m_updateTanFileColor(row, col, project.getLeftColor());   //updates project's appropriate frame with color information
+	// Determine whether it was a left or right click
+	if (btn == 'L')
+	{
+		m_color = project.getLeftColor();
+	}
+	else if (btn == 'R')
+	{
+		m_color = project.getRightColor();
+	}
+	// Then update the cell color
+	m_setCellColor(m_cell, m_color);
+	// And update the corresponding color in the Tan file representation
+	m_updateTanFileColor(row, col, m_color);
 }
 
-void MainWindow::on_cell_rightChanged(const int row, const int col, QColor m_color)
-{
-    nothingToSave = false;
-    //take provided color and assign it to the
-    QString m_cellName = m_getObjName(QObject::sender());
-    CellWidget *m_cell = MainWindow::findChild<CellWidget*>(m_cellName);
-    m_setCellColor(m_cell,project.getRightColor());
-    m_updateTanFileColor(row, col, project.getRightColor());   //updates project's appropriate frame with color information
-}
 
 // Update the corresponding Cell struct in TanFrame when color is changed in a cell widget.
 void MainWindow::m_updateTanFileColor(const int row, const int col, QColor m_color)
 {
     TanFrame frame;
-    frame.pixels[col][row].color = m_color;
+
+		frame.pixels[col][row].color = m_color;
+		nothingToSave = false;
 	// Need to determine how to identify each frame
 	/*
 	struct TanFrame *frame = project->m_frames...@iterator@node_identifier;
@@ -334,6 +329,7 @@ QString MainWindow::m_getObjName(QObject *m_obj) {
 	QString m_name = m_obj->property("objectName").toString();
 	return m_name;
 }
+
 
 void MainWindow::createActions()
 {

--- a/Tower_of_Lights_Editor_V3/mainwindow.h
+++ b/Tower_of_Lights_Editor_V3/mainwindow.h
@@ -41,9 +41,7 @@ private slots:
     void save();
     void saveAs();
 
-    //void on_cell_colorChanged(const int row, const int col, QColor m_color);
-    void on_cell_leftChanged(const int row, const int col, QColor m_color);
-    void on_cell_rightChanged(const int row, const int col, QColor m_color);
+		void on_cell_clicked(const int row, const int col, const char btn);
 
     void on_pushButton_2_clicked();
     void on_pushButton_3_clicked();


### PR DESCRIPTION
Remove the separate left and right-click handlers in MainWindow.
Changed the signal used from colorChanged to clicked.
Added a means within CellWidget's click handler to differentiate left
and right clicks.
Moved some of the locations of nothingToSave to better represent its
semantics.